### PR TITLE
Handle promise rejection at getOrDefault of data-cache

### DIFF
--- a/data-cache.js
+++ b/data-cache.js
@@ -427,6 +427,9 @@ DefaultDataCacheStrategy.prototype.getOrDefault = function(key, getFunc, absolut
                             }
                             return resolve(res);
                         });
+                    })
+                    .catch(function(err) {
+                        return reject(err);
                     });
                 }
                 catch(err) {


### PR DESCRIPTION
The data-cache module uses the `getOrDefault` function to call a user defined function on cache miss.

This PR adds a `catch` statement at the `getOrDefault` to catch errors on the user defined function.
